### PR TITLE
feat: implement search query update endpoint with http tests

### DIFF
--- a/http/search-query-create.http
+++ b/http/search-query-create.http
@@ -1,4 +1,4 @@
-### 201-Succefuly created / 409-Query already exists
+### 201-Successfully created / 409-Query already exists
 POST http://localhost:8086/api/job-market-analytics/search-query
 Content-Type: application/json
 X-User-Roles: ADMIN
@@ -58,6 +58,18 @@ X-User-Roles: ADMIN
 ### 400-Bad request (missing X-User-Roles)
 POST http://localhost:8086/api/job-market-analytics/search-query
 Content-Type: application/json
+
+{
+  "title": "Java Developer",
+  "query": "NAME:(!\"Java\") NOT QA NOT AQA",
+  "isEnabled": true
+}
+
+
+### 403-Access denied (X-User-Roles is empty)
+POST http://localhost:8086/api/job-market-analytics/search-query
+Content-Type: application/json
+X-User-Roles:
 
 {
   "title": "Java Developer",

--- a/http/search-query-update.http
+++ b/http/search-query-update.http
@@ -1,0 +1,114 @@
+### 200-Successfully updated (requires the existence of a record in the database id=1)
+PUT http://localhost:8086/api/job-market-analytics/search-query/1
+Content-Type: application/json
+X-User-Roles: ADMIN
+
+{
+  "title": "Python Developer",
+  "query": "NAME:(!\"Python\") NOT QA NOT AQA",
+  "isEnabled": true
+}
+
+
+### 400- Validation failed (invalid path id)
+PUT http://localhost:8086/api/job-market-analytics/search-query/abc
+Content-Type: application/json
+X-User-Roles: ADMIN
+
+{
+  "title": "Python Developer",
+  "query": "NAME:(!\"Python\") NOT QA NOT AQA",
+  "isEnabled": true
+}
+
+
+### 400-Validation failed (Title is missing)
+PUT http://localhost:8086/api/job-market-analytics/search-query/1
+Content-Type: application/json
+X-User-Roles: ADMIN
+
+{
+  "query": "NAME:(!\"Python\") NOT QA NOT AQA",
+  "isEnabled": true
+}
+
+
+### 400-Validation failed (Query is missing)
+PUT http://localhost:8086/api/job-market-analytics/search-query/1
+Content-Type: application/json
+X-User-Roles: ADMIN
+
+{
+  "title": "Python Developer",
+  "isEnabled": true
+}
+
+
+### 400-Validation failed (IsEnabled is null)
+PUT http://localhost:8086/api/job-market-analytics/search-query/1
+Content-Type: application/json
+X-User-Roles: ADMIN
+
+{
+  "title": "Python Developer",
+  "query": "NAME:(!\"Python\") NOT QA NOT AQA",
+  "isEnabled": null
+}
+
+
+### 400-Validation failed (IsEnabled is missing)
+PUT http://localhost:8086/api/job-market-analytics/search-query/1
+Content-Type: application/json
+X-User-Roles: ADMIN
+
+{
+  "title": "Python Developer",
+  "query": "NAME:(!\"Python\") NOT QA NOT AQA"
+}
+
+
+### 403-Access denied (X-User-Roles is missing)
+PUT http://localhost:8086/api/job-market-analytics/search-query/1
+Content-Type: application/json
+
+{
+  "title": "Python Developer",
+  "query": "NAME:(!\"Python\") NOT QA NOT AQA",
+  "isEnabled": true
+}
+
+
+### 403-Access denied (X-User-Roles is empty)
+PUT http://localhost:8086/api/job-market-analytics/search-query/1
+Content-Type: application/json
+X-User-Roles:
+
+{
+  "title": "Python Developer",
+  "query": "NAME:(!\"Python\") NOT QA NOT AQA",
+  "isEnabled": true
+}
+
+
+### 403-Access denied (X-User-Roles is wrong)
+PUT http://localhost:8086/api/job-market-analytics/search-query/1
+Content-Type: application/json
+X-User-Roles: STUDENT
+
+{
+  "title": "Python Developer",
+  "query": "NAME:(!\"Python\") NOT QA NOT AQA",
+  "isEnabled": true
+}
+
+
+### 404-Search query not found
+PUT http://localhost:8086/api/job-market-analytics/search-query/9999999
+Content-Type: application/json
+X-User-Roles: ADMIN
+
+{
+  "title": "Python Developer",
+  "query": "NAME:(!\"Python\") NOT QA NOT AQA",
+  "isEnabled": true
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/controller/SearchQueryController.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/controller/SearchQueryController.java
@@ -24,7 +24,7 @@ public class SearchQueryController {
             @RequestHeader("X-User-Roles") List<String> roles,
             @RequestBody @Valid SearchQueryRequest request) {
 
-        if (roles == null || roles.stream().noneMatch(r -> r.equalsIgnoreCase("ADMIN"))) {
+        if (roles.stream().noneMatch("ADMIN"::equalsIgnoreCase)) {
             throw new AccessDeniedException("Access denied");
         }
 
@@ -33,5 +33,20 @@ public class SearchQueryController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(response);
+    }
+
+    @PutMapping("/search-query/{id}")
+    public ResponseEntity<Void> updateSearchQuery(
+            @RequestHeader("X-User-Roles") List<String> roles,
+            @RequestBody @Valid SearchQueryRequest request,
+            @PathVariable("id") Long queryId) {
+
+        if (roles.stream().noneMatch("ADMIN"::equalsIgnoreCase)) {
+            throw new AccessDeniedException("Access denied");
+        }
+
+        searchQueryService.update(queryId, request);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.Objects;
 
@@ -67,6 +68,23 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
                 .body(new ErrorResponseDto(e.getMessage()));
+    }
+
+    @ExceptionHandler(SearchQueryNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handleSearchQueryNotFoundException(SearchQueryNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDto(e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponseDto> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.warn("Invalid parameter. name={}, type={}, value={}",
+                e.getName(),
+                e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown",
+                e.getValue());
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponseDto("Invalid request"));
     }
 
     @ExceptionHandler(DbActionExecutionException.class)

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/exception/SearchQueryNotFoundException.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/exception/SearchQueryNotFoundException.java
@@ -1,0 +1,7 @@
+package com.itmentorcommunityplatform.job_market_analytics_service.exception;
+
+public class SearchQueryNotFoundException extends RuntimeException {
+    public SearchQueryNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/service/SearchQueryService.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/service/SearchQueryService.java
@@ -3,10 +3,12 @@ package com.itmentorcommunityplatform.job_market_analytics_service.service;
 import com.itmentorcommunityplatform.job_market_analytics_service.domain.SearchQuery;
 import com.itmentorcommunityplatform.job_market_analytics_service.dto.SearchQueryRequest;
 import com.itmentorcommunityplatform.job_market_analytics_service.dto.SearchQueryResponse;
+import com.itmentorcommunityplatform.job_market_analytics_service.exception.SearchQueryNotFoundException;
 import com.itmentorcommunityplatform.job_market_analytics_service.mapper.SearchQueryMapper;
 import com.itmentorcommunityplatform.job_market_analytics_service.repository.SearchQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,5 +22,17 @@ public class SearchQueryService {
         SearchQuery saved = searchQueryRepository.save(searchQuery);
 
         return searchQueryMapper.mapToSearchQueryResponse(saved);
+    }
+
+    @Transactional
+    public void update(Long queryId, SearchQueryRequest request) {
+        SearchQuery existingSearchQuery = searchQueryRepository.findById(queryId)
+                .orElseThrow(() -> new SearchQueryNotFoundException("Search query not found"));
+
+        existingSearchQuery.setTitle(request.title());
+        existingSearchQuery.setQuery(request.query());
+        existingSearchQuery.setEnabled(request.isEnabled());
+
+        searchQueryRepository.save(existingSearchQuery);
     }
 }


### PR DESCRIPTION
## Что сделано  
- добавлен эндпоинт PUT /api/job-market-analytics/search-query/{id}  
- реализовано обновление поискового запроса в БД по id  
- добавлены ручные .http тесты для успешного и неуспешных сценариев 
 