### PR TITLE
feat-search-queries-api-6

### DIFF
--- a/http/search-queries.http
+++ b/http/search-queries.http
@@ -1,0 +1,18 @@
+### 1. Успешное получение всех search queries без фильтации
+GET http://localhost:8086/api/job-market-analytics/search-query
+Content-Type: application/json
+
+
+### 2. Успешное получение только активных search queries
+GET http://localhost:8086/api/job-market-analytics/search-query?isEnabled=true
+Content-Type: application/json
+
+
+### 3. Успешное получение только неактивных search queries
+GET http://localhost:8086/api/job-market-analytics/search-query?isEnabled=false
+Content-Type: application/json
+
+
+### 4. Невалидный параметр isEnabled (ожидается 400)
+GET http://localhost:8086/api/job-market-analytics/search-query?isEnabled=abc
+Content-Type: application/json

--- a/http/search-queries.http
+++ b/http/search-queries.http
@@ -1,18 +1,18 @@
-### 1. Успешное получение всех search queries без фильтации
+### 1. Successfully retrieve all search queries without filtering
 GET http://localhost:8086/api/job-market-analytics/search-query
 Content-Type: application/json
 
 
-### 2. Успешное получение только активных search queries
+### 2. Successfully retrieve only enabled search queries
 GET http://localhost:8086/api/job-market-analytics/search-query?isEnabled=true
 Content-Type: application/json
 
 
-### 3. Успешное получение только неактивных search queries
+### 3. Successfully retrieve only disabled search queries
 GET http://localhost:8086/api/job-market-analytics/search-query?isEnabled=false
 Content-Type: application/json
 
 
-### 4. Невалидный параметр isEnabled (ожидается 400)
+### 4. Invalid isEnabled parameter (expected 400 Bad Request)
 GET http://localhost:8086/api/job-market-analytics/search-query?isEnabled=abc
 Content-Type: application/json

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/controller/SearchQueryController.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/controller/SearchQueryController.java
@@ -49,4 +49,15 @@ public class SearchQueryController {
 
         return ResponseEntity.ok().build();
     }
+
+    @GetMapping("/search-query")
+    public ResponseEntity<List<SearchQueryResponse>> getSearchQueries(
+            @RequestParam(required = false) Boolean isEnabled) {
+
+        List<SearchQueryResponse> responses = searchQueryService.getSearchQueries(isEnabled);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(responses);
+    }
 }

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/controller/SearchQueryController.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/controller/SearchQueryController.java
@@ -56,8 +56,6 @@ public class SearchQueryController {
 
         List<SearchQueryResponse> responses = searchQueryService.getSearchQueries(isEnabled);
 
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(responses);
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/exception/GlobalExceptionHandler.java
@@ -20,15 +20,6 @@ import java.util.Objects;
 @Slf4j
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponseDto> handleException(Exception e) {
-        log.error("Unexpected error occurred.", e);
-
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponseDto("Internal server error"));
-    }
-
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponseDto> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
         String message = Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage();
@@ -110,5 +101,23 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponseDto("Bad request"));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponseDto> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponseDto("Invalid request parameter"));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDto> handleException(Exception e) {
+        log.error("Unexpected error occurred.", e);
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponseDto("Internal server error"));
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/exception/GlobalExceptionHandler.java
@@ -103,15 +103,6 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponseDto("Bad request"));
     }
 
-    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ErrorResponseDto> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
-        log.warn(e.getMessage());
-
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponseDto("Invalid request parameter"));
-    }
-
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponseDto> handleException(Exception e) {
         log.error("Unexpected error occurred.", e);

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/repository/SearchQueryRepository.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/repository/SearchQueryRepository.java
@@ -3,6 +3,10 @@ package com.itmentorcommunityplatform.job_market_analytics_service.repository;
 import com.itmentorcommunityplatform.job_market_analytics_service.domain.SearchQuery;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
+
 public interface SearchQueryRepository extends CrudRepository<SearchQuery, Long> {
 
+    List<SearchQuery> findByIsEnabled(boolean isEnabled);
+    List<SearchQuery> findAll();
 }

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/repository/SearchQueryRepository.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/repository/SearchQueryRepository.java
@@ -1,12 +1,11 @@
 package com.itmentorcommunityplatform.job_market_analytics_service.repository;
 
 import com.itmentorcommunityplatform.job_market_analytics_service.domain.SearchQuery;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.ListCrudRepository;
 
 import java.util.List;
 
-public interface SearchQueryRepository extends CrudRepository<SearchQuery, Long> {
+public interface SearchQueryRepository extends ListCrudRepository<SearchQuery, Long> {
 
     List<SearchQuery> findByIsEnabled(boolean isEnabled);
-    List<SearchQuery> findAll();
 }

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/service/SearchQueryService.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/service/SearchQueryService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class SearchQueryService {
@@ -22,6 +24,16 @@ public class SearchQueryService {
         SearchQuery saved = searchQueryRepository.save(searchQuery);
 
         return searchQueryMapper.mapToSearchQueryResponse(saved);
+    }
+
+    public List<SearchQueryResponse> getSearchQueries(Boolean isEnabled) {
+        List<SearchQuery> queries = isEnabled == null
+                ? searchQueryRepository.findAll()
+                : searchQueryRepository.findByIsEnabled(isEnabled);
+
+        return queries.stream()
+                .map(searchQueryMapper::mapToSearchQueryResponse)
+                .toList();
     }
 
     @Transactional


### PR DESCRIPTION
## Реализация эндпоинта получения поисковых запросов

В рамках задачи реализован эндпоинт для получения списка поисковых запросов с возможностью фильтрации по признаку активности.


## Что сделано

- Реализован эндпоинт:
  GET /api/job-market-analytics/search-queries

- Добавлена фильтрация по параметру:
  - isEnabled (optional)

- Реализована логика:
  - при отсутствии параметра возвращаются все записи
  - при наличии — фильтрация по значению

- Добавлена обработка ошибок:
  - невалидный query параметр → 400 Bad Request

- Добавлены ручные .http тесты:
  - успешный сценарий без фильтра
  - успешный сценарий с фильтром
  - невалидный параметр
