### PR TITLE
feat: add job analytics scheduler via HeadHunter API

### DIFF
--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/client/HhClient.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/client/HhClient.java
@@ -1,45 +1,85 @@
 package com.itmentorcommunityplatform.job_market_analytics_service.client;
 
+import com.itmentorcommunityplatform.job_market_analytics_service.dto.response.HhVacancySearchResponse;
 import com.itmentorcommunityplatform.job_market_analytics_service.exception.ExternalServiceException;
-import com.itmentorcommunityplatform.job_market_analytics_service.exception.RateLimitExceededException;
 import com.itmentorcommunityplatform.job_market_analytics_service.metrics.ProfileMetrics;
 import io.github.bucket4j.Bucket;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class HhClient {
+    private static final DateTimeFormatter HH_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXX");
 
     private final RestClient restClient;
     private final ProfileMetrics profileMetrics;
     private final Bucket hhApiBucket;
 
-    public String searchVacancies(String query) {
-        if (!hhApiBucket.tryConsume(1)) {
-            log.warn("HH API rate limit exceeded");
-            throw new RateLimitExceededException("There are too many requests to an external service");
-        }
+    public HhVacancySearchResponse searchVacancies(String query, OffsetDateTime dateFrom, OffsetDateTime dateTo, int page, int perPage) {
+        waitForRateLimitPermit();
+        String from = dateFrom.truncatedTo(ChronoUnit.SECONDS).format(HH_DATE_TIME_FORMATTER);
+        String to = dateTo.truncatedTo(ChronoUnit.SECONDS).format(HH_DATE_TIME_FORMATTER);
 
         try {
-            String response = restClient.get()
+            HhVacancySearchResponse response = restClient.get()
                     .uri(uriBuilder -> uriBuilder
                             .path("/vacancies")
-                            .queryParam("text", query)
-                            .build())
+                            .queryParam("text", "{text}")
+                            .queryParam("date_from", "{dateFrom}")
+                            .queryParam("date_to", "{dateTo}")
+                            .queryParam("page", "{page}")
+                            .queryParam("per_page", "{perPage}")
+                            .build(Map.of(
+                                    "text", query,
+                                    "dateFrom", from,
+                                    "dateTo", to,
+                                    "page", page,
+                                    "perPage", perPage
+                            )))
                     .retrieve()
-                    .body(String.class);
+                    .body(HhVacancySearchResponse.class);
 
-            log.info("HH API request successful. query='{}'", query);
+            if (response == null) {
+                throw new ExternalServiceException("Empty response from HH API");
+            }
+
+            log.debug("HH API request completed. searchQueryText='{}', page={}, perPage={}", query, page, perPage);
             return response;
 
-        } catch (Exception e) {
-            log.error("HH API request failed for query '{}'", query, e);
+        } catch (HttpClientErrorException.BadRequest e) {
+            log.error("HH API returned 400 Bad Request. searchQueryText='{}', from='{}', to='{}', body={}",
+                    query, from, to, e.getResponseBodyAsString(), e);
+            profileMetrics.getRequestErrorCounter().increment();
+            throw new ExternalServiceException("Invalid request to HH API");
+        } catch (RestClientException e) {
+            log.error("HH API request failed. searchQueryText='{}', from='{}', to='{}'",
+                    query, from, to, e);
             profileMetrics.getRequestErrorCounter().increment();
             throw new ExternalServiceException("Failed to fetch data from HH API");
+        } catch (Exception e) {
+            log.error("HH API request failed for searchQueryText '{}'", query, e);
+            profileMetrics.getRequestErrorCounter().increment();
+            throw new ExternalServiceException("Failed to fetch data from HH API");
+        }
+    }
+
+    private void waitForRateLimitPermit() {
+        try {
+            hhApiBucket.asBlocking().consume(1);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ExternalServiceException("Interrupted while waiting for HH API rate limit permit");
         }
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/config/RateLimitConfig.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/config/RateLimitConfig.java
@@ -14,11 +14,13 @@ public class RateLimitConfig {
     public Bucket hhApiBucket(
             @Value("${rate-limit.capacity}") int capacity,
             @Value("${rate-limit.refill}") int refill,
+            @Value("${rate-limit.initial-tokens}") int initialTokens,
             @Value("${rate-limit.period}") Duration period
     ) {
         Bandwidth limit = Bandwidth.builder()
                 .capacity(capacity)
                 .refillGreedy(refill, period)
+                .initialTokens(initialTokens)
                 .build();
 
         return Bucket.builder()

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/config/SchedulerConfig.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/config/SchedulerConfig.java
@@ -1,0 +1,11 @@
+package com.itmentorcommunityplatform.job_market_analytics_service.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(name = "scheduler.enabled", matchIfMissing = true)
+public class SchedulerConfig {
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/controller/VacancyControllerTest.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/controller/VacancyControllerTest.java
@@ -1,5 +1,6 @@
 package com.itmentorcommunityplatform.job_market_analytics_service.controller;
 
+import com.itmentorcommunityplatform.job_market_analytics_service.dto.response.HhVacancySearchResponse;
 import com.itmentorcommunityplatform.job_market_analytics_service.service.VacancyService;
 import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ public class VacancyControllerTest {
 
     @PostMapping("/test-search")
     @Hidden
-    public ResponseEntity<String> vacancySearchTest(@RequestParam String search) {
+    public ResponseEntity<HhVacancySearchResponse> vacancySearchTest(@RequestParam String search) {
         return ResponseEntity.ok(vacancyService.searchVacancies(search));
-    } 
+    }
 }

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/domain/scheduler/HhMarketDataJob.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/domain/scheduler/HhMarketDataJob.java
@@ -1,0 +1,14 @@
+package com.itmentorcommunityplatform.job_market_analytics_service.domain.scheduler;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+public record HhMarketDataJob(
+        Long id,
+        Long searchQueryId,
+        LocalDate snapshotDate,
+        OffsetDateTime dateFrom,
+        OffsetDateTime dateTo,
+        String searchQueryText
+) {
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/dto/HhMarketDataRequest.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/dto/HhMarketDataRequest.java
@@ -1,0 +1,13 @@
+package com.itmentorcommunityplatform.job_market_analytics_service.dto;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+public record HhMarketDataRequest(
+        Long id,
+        LocalDate snapshotDate,
+        OffsetDateTime dateFrom,
+        OffsetDateTime dateTo,
+        String searchQueryText
+) {
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/dto/response/HhSalaryResponse.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/dto/response/HhSalaryResponse.java
@@ -1,0 +1,23 @@
+package com.itmentorcommunityplatform.job_market_analytics_service.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record HhSalaryResponse(
+
+        @JsonProperty("from")
+        BigDecimal from,
+
+        @JsonProperty("to")
+        BigDecimal to,
+
+        @JsonProperty("currency")
+        String currency,
+
+        @JsonProperty("gross")
+        Boolean gross
+) {
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/dto/response/HhVacancyItemResponse.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/dto/response/HhVacancyItemResponse.java
@@ -1,0 +1,15 @@
+package com.itmentorcommunityplatform.job_market_analytics_service.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record HhVacancyItemResponse(
+
+        @JsonProperty("id")
+        String id,
+
+        @JsonProperty("salary")
+        HhSalaryResponse salary
+) {
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/dto/response/HhVacancySearchResponse.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/dto/response/HhVacancySearchResponse.java
@@ -1,0 +1,26 @@
+package com.itmentorcommunityplatform.job_market_analytics_service.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record HhVacancySearchResponse(
+
+        @JsonProperty("items")
+        List<HhVacancyItemResponse> items,
+
+        @JsonProperty("found")
+        int found,
+
+        @JsonProperty("pages")
+        int pages,
+
+        @JsonProperty("page")
+        int page,
+
+        @JsonProperty("per_page")
+        int perPage
+) {
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/mapper/ScheduledJobMapper.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/mapper/ScheduledJobMapper.java
@@ -1,0 +1,13 @@
+package com.itmentorcommunityplatform.job_market_analytics_service.mapper;
+
+import com.itmentorcommunityplatform.job_market_analytics_service.domain.scheduler.HhMarketDataJob;
+import com.itmentorcommunityplatform.job_market_analytics_service.dto.HhMarketDataRequest;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ScheduledJobMapper {
+
+    @Mapping(target = "id", source = "searchQueryId")
+    HhMarketDataRequest toHhMarketDataRequest(HhMarketDataJob hhMarketDataJob);
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/mapper/SearchQueryMapper.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/mapper/SearchQueryMapper.java
@@ -10,8 +10,8 @@ import org.mapstruct.Mapping;
 public interface SearchQueryMapper {
 
     @Mapping(target = "enabled", source = "isEnabled")
-    SearchQuery mapToSearchQuery(SearchQueryRequest searchQueryRequest);
+    SearchQuery toSearchQuery(SearchQueryRequest searchQueryRequest);
 
     @Mapping(target = "isEnabled", source = "enabled")
-    SearchQueryResponse mapToSearchQueryResponse(SearchQuery searchQuery);
+    SearchQueryResponse toSearchQueryResponse(SearchQuery searchQuery);
 }

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/repository/HhScheduledJobRepository.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/repository/HhScheduledJobRepository.java
@@ -1,0 +1,55 @@
+package com.itmentorcommunityplatform.job_market_analytics_service.repository;
+
+import com.itmentorcommunityplatform.job_market_analytics_service.domain.scheduler.HhMarketDataJob;
+import org.springframework.data.jdbc.repository.query.Modifying;
+import org.springframework.data.jdbc.repository.query.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public interface HhScheduledJobRepository extends CrudRepository<HhMarketDataJob, Long> {
+
+    @Modifying
+    @Query("""
+            INSERT INTO hh_scheduled_jobs (search_query_id, snapshot_date, date_from, date_to, status)
+            SELECT id,
+                   :snapshotDate,
+                   :dateFrom,
+                   :dateTo,
+                   'NEW'
+            FROM search_queries
+            WHERE is_enabled = true
+            ON CONFLICT (search_query_id, snapshot_date) DO NOTHING
+            """)
+    int scheduleJobs(@Param("snapshotDate") LocalDate snapshotDate,
+                     @Param("dateFrom") OffsetDateTime dateFrom,
+                     @Param("dateTo") OffsetDateTime dateTo);
+
+    @Query("""
+                SELECT
+                    j.id               AS id,
+                    j.search_query_id  AS search_query_id,
+                    j.snapshot_date    AS snapshot_date,
+                    j.date_from        AS date_from,
+                    j.date_to          AS date_to,
+                    q.query            AS search_query_text
+                FROM hh_scheduled_jobs j
+                JOIN search_queries q ON q.id = j.search_query_id
+                WHERE j.status = 'NEW'
+                ORDER BY j.snapshot_date, j.search_query_id
+            """)
+    List<HhMarketDataJob> findNewJobs();
+
+    @Modifying
+    @Query(value = """
+            UPDATE hh_scheduled_jobs
+            SET status = 'DONE'
+            WHERE id = :jobId
+              AND status = 'NEW'
+            """)
+    void markJobDone(@Param("jobId") Long jobId);
+
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/repository/MarketDataPointRepository.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/repository/MarketDataPointRepository.java
@@ -1,0 +1,55 @@
+package com.itmentorcommunityplatform.job_market_analytics_service.repository;
+
+import com.itmentorcommunityplatform.job_market_analytics_service.domain.MarketDataPoint;
+import org.springframework.data.jdbc.repository.query.Modifying;
+import org.springframework.data.jdbc.repository.query.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public interface MarketDataPointRepository extends CrudRepository<MarketDataPoint, Long> {
+
+    @Modifying
+    @Query("""
+            INSERT INTO market_data_points (
+                search_query_id,
+                snapshot_date,
+                vacancy_count,
+                avg_salary,
+                median_salary_mid,
+                created_at
+            )
+            VALUES (
+                :searchQueryId,
+                :snapshotDate,
+                :vacancyCount,
+                :avgSalary,
+                :medianSalaryMid,
+                :createdAt
+            )
+            ON CONFLICT (search_query_id, snapshot_date) DO NOTHING
+            """)
+    int insertIgnoreRaw(
+            @Param("searchQueryId") Long searchQueryId,
+            @Param("snapshotDate") LocalDate snapshotDate,
+            @Param("vacancyCount") Integer vacancyCount,
+            @Param("avgSalary") BigDecimal avgSalary,
+            @Param("medianSalaryMid") BigDecimal medianSalaryMid,
+            @Param("createdAt") LocalTime createdAt
+    );
+
+    default int insertIfAbsent(MarketDataPoint point) {
+        return insertIgnoreRaw(
+                point.getSearchQueryId(),
+                point.getSnapshotDate(),
+                point.getVacancyCount(),
+                point.getAvgSalary(),
+                point.getMedianSalaryMid(),
+                point.getCreatedAt()
+        );
+
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/scheduler/HhMarketDataScheduler.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/scheduler/HhMarketDataScheduler.java
@@ -1,0 +1,86 @@
+package com.itmentorcommunityplatform.job_market_analytics_service.scheduler;
+
+import com.itmentorcommunityplatform.job_market_analytics_service.domain.scheduler.HhMarketDataJob;
+import com.itmentorcommunityplatform.job_market_analytics_service.dto.HhMarketDataRequest;
+import com.itmentorcommunityplatform.job_market_analytics_service.mapper.ScheduledJobMapper;
+import com.itmentorcommunityplatform.job_market_analytics_service.repository.HhScheduledJobRepository;
+import com.itmentorcommunityplatform.job_market_analytics_service.service.MarketDataCollectionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HhMarketDataScheduler {
+
+    private final MarketDataCollectionService marketDataCollectionService;
+    private final HhScheduledJobRepository hhScheduledJobRepository;
+    private final ScheduledJobMapper scheduledJobMapper;
+
+    @Value("${scheduler.zone}")
+    private ZoneId hhApiZone;
+
+    @Value("${hh.collection.lookback-days}")
+    private int searchPeriodDays;
+
+    @Scheduled(
+            cron = "${scheduler.cron}",
+            zone = "${scheduler.zone}")
+    public void scheduleMarketDataJobs() {
+        OffsetDateTime now = OffsetDateTime.now(hhApiZone).truncatedTo(ChronoUnit.SECONDS);
+        LocalDate snapshotDate = now.toLocalDate();
+        OffsetDateTime searchDateFrom = now.minusDays(searchPeriodDays);
+        int createdJobs = hhScheduledJobRepository.scheduleJobs(snapshotDate, searchDateFrom, now);
+
+        if (createdJobs > 0) {
+            log.info("Scheduled market data jobs. snapshotDate={}, createdJobs={}", snapshotDate, createdJobs);
+        } else {
+            log.info("Scheduler worked but no new tasks were scheduled");
+        }
+    }
+
+    @Scheduled(
+            cron = "${scheduler.worker.cron}",
+            zone = "${scheduler.zone}")
+    public void collectHhMarketData() {
+        List<HhMarketDataJob> jobs = hhScheduledJobRepository.findNewJobs();
+        log.info("Market data collection started. jobsToProcess={}", jobs.size());
+
+        int done = 0;
+        int failed = 0;
+        int skipped = 0;
+
+        for (HhMarketDataJob job : jobs) {
+            HhMarketDataRequest request = scheduledJobMapper.toHhMarketDataRequest(job);
+
+            try {
+                int completedJob = marketDataCollectionService.collectAndSaveMarketData(request);
+                done += completedJob;
+
+                if (completedJob == 0) {
+                    skipped++;
+                    log.info("Skipped market data insert because snapshot already exists. jobId={}, searchQueryId={}, snapshotDate={}",
+                            job.id(), job.searchQueryId(), job.snapshotDate());
+                    continue;
+                }
+
+                hhScheduledJobRepository.markJobDone(job.id());
+            } catch (Exception e) {
+                failed++;
+                log.error("Market data job failed. jobId={}, searchQueryId={}, snapshotDate={}",
+                        job.id(), job.searchQueryId(), job.snapshotDate(), e);
+            }
+        }
+
+        log.info("Scheduler worker finished. tasks={}, done={}, failed={}, skipped={}", jobs.size(), done, failed, skipped);
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/service/MarketDataAggregationService.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/service/MarketDataAggregationService.java
@@ -1,0 +1,111 @@
+package com.itmentorcommunityplatform.job_market_analytics_service.service;
+
+import com.itmentorcommunityplatform.job_market_analytics_service.domain.MarketDataPoint;
+import com.itmentorcommunityplatform.job_market_analytics_service.dto.response.HhVacancyItemResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+public class MarketDataAggregationService {
+
+    @Value("${scheduler.zone}")
+    private ZoneId hhApiZone;
+
+    public MarketDataPoint aggregateToMarketDataPoint(Long searchQueryId, LocalDate snapshotDate, List<HhVacancyItemResponse> vacancies) {
+        MarketDataPoint marketDataPoint = new MarketDataPoint();
+        marketDataPoint.setSearchQueryId(searchQueryId);
+        marketDataPoint.setSnapshotDate(snapshotDate);
+        marketDataPoint.setVacancyCount(vacancies.size());
+        marketDataPoint.setCreatedAt(LocalTime.now(hhApiZone).truncatedTo(ChronoUnit.SECONDS));
+
+        if (vacancies.isEmpty()) {
+            marketDataPoint.setAvgSalary(BigDecimal.ZERO);
+            marketDataPoint.setMedianSalaryMid(BigDecimal.ZERO);
+            return marketDataPoint;
+        }
+
+        List<BigDecimal> salaries = new ArrayList<>();
+
+        for (HhVacancyItemResponse item : vacancies) {
+            BigDecimal normalizedSalary = extractNormalizedRubSalary(item);
+            if (normalizedSalary != null) {
+                salaries.add(normalizedSalary);
+            }
+        }
+
+        marketDataPoint.setAvgSalary(calculateAverage(salaries));
+        marketDataPoint.setMedianSalaryMid(calculateMedian(salaries));
+
+        return marketDataPoint;
+    }
+
+    private BigDecimal extractNormalizedRubSalary(HhVacancyItemResponse item) {
+        if (item == null || item.salary() == null) {
+            return null;
+        }
+
+        var salary = item.salary();
+
+        if (!"RUR".equals(salary.currency())) {
+            return null;
+        }
+
+        BigDecimal from = salary.from();
+        BigDecimal to = salary.to();
+
+        if (from != null && to != null) {
+            return from.add(to).divide(BigDecimal.valueOf(2), 0, RoundingMode.HALF_UP);
+        }
+
+        if (from != null) {
+            return from;
+        }
+
+        return to;
+    }
+
+    private BigDecimal calculateAverage(List<BigDecimal> salaries) {
+        if (salaries.isEmpty()) {
+            return BigDecimal.ZERO;
+        }
+
+        BigDecimal sum = BigDecimal.ZERO;
+
+        for (BigDecimal salary : salaries) {
+            sum = sum.add(salary);
+        }
+
+        return sum.divide(BigDecimal.valueOf(salaries.size()), 0, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal calculateMedian(List<BigDecimal> salaries) {
+        if (salaries.isEmpty()) {
+            return BigDecimal.ZERO;
+        }
+
+        List<BigDecimal> sorted = new ArrayList<>(salaries);
+        sorted.sort(Comparator.naturalOrder());
+
+        int size = sorted.size();
+        int middle = size / 2;
+
+        if (size % 2 == 1) {
+            return sorted.get(middle);
+        }
+
+        BigDecimal left = sorted.get(middle - 1);
+        BigDecimal right = sorted.get(middle);
+
+        return left.add(right).divide(BigDecimal.valueOf(2), 0, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/service/MarketDataCollectionService.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/service/MarketDataCollectionService.java
@@ -1,0 +1,107 @@
+package com.itmentorcommunityplatform.job_market_analytics_service.service;
+
+import com.itmentorcommunityplatform.job_market_analytics_service.client.HhClient;
+import com.itmentorcommunityplatform.job_market_analytics_service.domain.MarketDataPoint;
+import com.itmentorcommunityplatform.job_market_analytics_service.dto.HhMarketDataRequest;
+import com.itmentorcommunityplatform.job_market_analytics_service.dto.response.HhVacancyItemResponse;
+import com.itmentorcommunityplatform.job_market_analytics_service.dto.response.HhVacancySearchResponse;
+import com.itmentorcommunityplatform.job_market_analytics_service.repository.MarketDataPointRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MarketDataCollectionService {
+    private static final int HH_RESULT_LIMIT = 2000;
+    private static final int FIRST_PAGE = 0;
+    private static final int PER_PAGE = 100;
+    private static final int MIN_SPLIT_WINDOW = 5;
+
+    private final MarketDataAggregationService marketDataAggregationService;
+    private final MarketDataPointRepository marketDataPointRepository;
+    private final HhClient hhClient;
+
+    public int collectAndSaveMarketData(HhMarketDataRequest searchRequest) {
+        Map<String, HhVacancyItemResponse> uniqueVacanciesById = new HashMap<>();
+
+        fetchVacancies(searchRequest, searchRequest.dateFrom(), searchRequest.dateTo(), uniqueVacanciesById);
+
+        List<HhVacancyItemResponse> vacanciesValue = new ArrayList<>(uniqueVacanciesById.values());
+        MarketDataPoint point = marketDataAggregationService
+                .aggregateToMarketDataPoint(searchRequest.id(), searchRequest.snapshotDate(), vacanciesValue);
+
+        return marketDataPointRepository.insertIfAbsent(point);
+    }
+
+    private void fetchVacancies(
+            HhMarketDataRequest searchRequest,
+            OffsetDateTime from,
+            OffsetDateTime to,
+            Map<String, HhVacancyItemResponse> uniqueVacanciesById
+    ) {
+        String searchText = searchRequest.searchQueryText();
+
+        HhVacancySearchResponse firstPageResult = hhClient.searchVacancies(searchText, from, to, FIRST_PAGE, PER_PAGE);
+        int totalFound = firstPageResult.found();
+
+        if (totalFound <= HH_RESULT_LIMIT) {
+            fetchAllPages(searchText, from, to, firstPageResult, uniqueVacanciesById);
+            return;
+        }
+
+        if (!canSplitFurther(from, to)) {
+            log.warn("HH response still exceeds 2000 results in minimal time window - data may be distorted. searchQueryId={}, from={}, to={}, totalFound={}",
+                    searchRequest.id(), from, to, totalFound);
+            fetchAllPages(searchText, from, to, firstPageResult, uniqueVacanciesById);
+            return;
+        }
+
+        OffsetDateTime mid = midpoint(from, to);
+
+        fetchVacancies(searchRequest, from, mid, uniqueVacanciesById);
+        fetchVacancies(searchRequest, mid, to, uniqueVacanciesById);
+    }
+
+    private void fetchAllPages(
+            String searchText,
+            OffsetDateTime from,
+            OffsetDateTime to,
+            HhVacancySearchResponse firstPageResult,
+            Map<String, HhVacancyItemResponse> uniqueVacanciesById
+    ) {
+        addUniqueVacancies(firstPageResult.items(), uniqueVacanciesById);
+
+        for (int page = 1; page < firstPageResult.pages(); page++) {
+            HhVacancySearchResponse response = hhClient.searchVacancies(searchText, from, to, page, PER_PAGE);
+            addUniqueVacancies(response.items(), uniqueVacanciesById);
+        }
+    }
+
+    private void addUniqueVacancies(List<HhVacancyItemResponse> items, Map<String, HhVacancyItemResponse> uniqueVacanciesById) {
+        if (items == null || items.isEmpty()) {
+            return;
+        }
+        for (HhVacancyItemResponse item : items) {
+            if (item != null && item.id() != null) {
+                uniqueVacanciesById.putIfAbsent(item.id(), item);
+            }
+        }
+    }
+
+    private boolean canSplitFurther(OffsetDateTime from, OffsetDateTime to) {
+        return Duration.between(from, to).toMinutes() > MIN_SPLIT_WINDOW;
+    }
+
+    private OffsetDateTime midpoint(OffsetDateTime from, OffsetDateTime to) {
+        return from.plus(Duration.between(from, to).dividedBy(2));
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/service/SearchQueryService.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/service/SearchQueryService.java
@@ -24,10 +24,10 @@ public class SearchQueryService {
     private final SearchQueriesMetrics searchQueriesMetrics;
 
     public SearchQueryResponse save(SearchQueryRequest request) {
-        SearchQuery searchQuery = searchQueryMapper.mapToSearchQuery(request);
+        SearchQuery searchQuery = searchQueryMapper.toSearchQuery(request);
         SearchQuery saved = searchQueryRepository.save(searchQuery);
 
-        return searchQueryMapper.mapToSearchQueryResponse(saved);
+        return searchQueryMapper.toSearchQueryResponse(saved);
     }
 
     public List<SearchQueryResponse> getSearchQueries(Boolean isEnabled) {
@@ -38,14 +38,14 @@ public class SearchQueryService {
                 : searchQueryRepository.findByIsEnabled(isEnabled);
 
         return queries.stream()
-                .map(searchQueryMapper::mapToSearchQueryResponse)
+                .map(searchQueryMapper::toSearchQueryResponse)
                 .toList();
     }
 
     @Transactional
     public void update(Long queryId, SearchQueryRequest request) {
         SearchQuery existingSearchQuery = searchQueryRepository.findById(queryId)
-                .orElseThrow(() -> new SearchQueryNotFoundException("Search query not found"));
+                .orElseThrow(() -> new SearchQueryNotFoundException("Search searchQueryText not found"));
 
         existingSearchQuery.setTitle(request.title());
         existingSearchQuery.setQuery(request.query());

--- a/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/service/VacancyService.java
+++ b/src/main/java/com/itmentorcommunityplatform/job_market_analytics_service/service/VacancyService.java
@@ -1,16 +1,31 @@
 package com.itmentorcommunityplatform.job_market_analytics_service.service;
 
 import com.itmentorcommunityplatform.job_market_analytics_service.client.HhClient;
+import com.itmentorcommunityplatform.job_market_analytics_service.dto.response.HhVacancySearchResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 
 @Service
 @RequiredArgsConstructor
 public class VacancyService {
 
+    @Value("${hh.collection.lookback-days}")
+    private int searchPeriodDays;
+
+    @Value("${scheduler.zone}")
+    private ZoneId hhApiZone;
+
     private final HhClient hhClient;
 
-    public String searchVacancies(String query) {
-        return hhClient.searchVacancies(query);
+    public HhVacancySearchResponse searchVacancies(String query) {
+        OffsetDateTime to = OffsetDateTime.now(hhApiZone);
+        OffsetDateTime from = to.minusDays(searchPeriodDays);
+        int defaultPage = 0;
+        int perPage = 100;
+        return hhClient.searchVacancies(query, from, to, defaultPage, perPage);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,11 +5,21 @@ spring:
 hh:
   api:
     url: https://api.hh.ru
+  collection:
+    lookback-days: 60
 
 rate-limit:
-  capacity: 10
-  refill: 10
-  period: 60s
+  capacity: 1
+  refill: 1
+  period: 2s
+  initial-tokens: 0
+
+scheduler:
+  enabled: true
+  zone: Europe/Moscow
+  cron: "0 0 0 * * *"
+  worker:
+    cron: "0 */30 * * * *"
 
 management:
   metrics:

--- a/src/main/resources/db/changelog/changesets/004-create-table-jobs.sql
+++ b/src/main/resources/db/changelog/changesets/004-create-table-jobs.sql
@@ -1,0 +1,11 @@
+CREATE TABLE hh_scheduled_jobs
+(
+    id              BIGSERIAL PRIMARY KEY,
+    search_query_id BIGINT      NOT NULL,
+    snapshot_date   DATE        NOT NULL,
+    date_from       TIMESTAMPTZ NOT NULL,
+    date_to         TIMESTAMPTZ NOT NULL,
+    status          TEXT        NOT NULL,
+    CHECK (status IN ('NEW', 'DONE')),
+    CONSTRAINT uk_hh_collection_job UNIQUE (search_query_id, snapshot_date)
+);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5,3 +5,5 @@ databaseChangeLog:
       file: db/changelog/changesets/002-unique-constraint.sql
   - include:
       file: db/changelog/changesets/003-change-constraint.sql
+  - include:
+      file: db/changelog/changesets/004-create-table-jobs.sql


### PR DESCRIPTION
Реализован планировщик для сбора аналитики по активным поисковым запросам из HeadHunter API с последующим сохранением агрегированных данных в БД.

## Что сделано:
- Добавлена таблица заданий планировщика: hh_scheduled_jobs
  - Добавлено ограничение:
uk_hh_collection_job (search_query_id, snapshot_date)
Предотвращает повторную постановку одинакового задания на один и тот же поисковый запрос и дату.

- Реализован scheduler для постановки заданий: HhMarketDataScheduler.scheduleMarketDataJobs(), который запускается по cron-выражению из конфигурации.
  - Что делает:
определяет текущую дату snapshot;
вычисляет период поиска (now - lookbackDays ... now);
создает задания для всех активных search query из таблицы search_queries;
использует INSERT ... SELECT ... ON CONFLICT DO NOTHING, чтобы одинаковые задания не создавались повторно.

- Реализован worker для обработки заданий HhMarketDataScheduler.collectHhMarketData(), который запускается по cron-выражению из конфигурации.
  - Что делает:
выбирает все задания со статусом NEW;
преобразует их в запрос к HH API;
запускает сбор и агрегацию данных;
сохраняет snapshot в market_data_points;
после успешной обработки помечает задание как DONE.

- Изменен HhClient:
  - Вместо String результат парсится в DTO
  - Добавлена работа с временными отрезками
  - добавлена пагинация
  - вакансии ищутся в промежутке: "заданное время - 60 дней". Т.к. у HH в респонсе есть 2 даты: создание и обновление вакансии - и видимо не все работодатели регулярно обновляют их. И если делать поисковой запрос меньше чем 60 дней назад - то тот foundVacancies что на HH не сходится с тем что удается найти программе

- Изменен RateLimit:
  - изменена работа: теперь при достижении лимита - блокируется, пока не добавится новый токен
  - лимиты изменены исходя из "стресс" условий, когда запросы шлют сразу 2 инстанса (2 инстанса параллельно обработали 80к вакансий с такими лимитами - HH такой rps устроил)

- Реализован обход лимита HH API в 2000 результатов
  - В MarketDataCollectionService реализована логика рекурсивного деления временного окна.
  - Алгоритм работы:
выполняется запрос по заданному интервалу времени;
если found <= 2000, загружаются все страницы;
если found > 2000, интервал делится пополам;
далее выполняется рекурсивный обход двух подинтервалов;
вакансии дедуплицируются по vacancy id.
**У такого подхода есть "Corner case" - HH округляет дату и время запроса до 5 минут - если вдруг (что мало вероятно) ХХ в интервале 5 минут выложит >2000 вакансий - то результат аналитика будет искажен (на всякий случай заллогировал такую ситуацию)

- Реализована агрегация в MarketDataPoint
  - Добавлен MarketDataAggregationService, который строит snapshot по собранным вакансиям
 
    Особенности расчета/Ограничения:
    -  учитываются ТОЛЬКО зарплаты в валюте RUR;
    -  если указаны from и to, берется их середина;
    - если указано только одно значение, используется оно;
    - если зарплатных данных нет, агрегаты сохраняются как 0.
    - не учитываются Gross/Net
    - ** На данный момент, аналитика не корректна - по причине, отсутствия в MarketDataPoint поля отвечающего за количество вакансий по которым были произведены расчеты зарплат: из 500 вакансий на Java - в лучше случае ЗП указали половина - но при этом аналитика у нас показывает, будто рассчитанная средняя и медианная ЗП - как для 500, что таковым не является.

- Реализована защита от повторной вставки аналитики
  - Для сохранения результата аналитики используется MarketDataPointRepository.insertIfAbsent(...) с ON CONFLICT DO NOTHING.
  - Таким образом, при работе нескольких инстансов:
    - несколько инстансов могут попытаться обработать один и тот же snapshot;
    - но только один сможет вставить запись в market_data_points благодаря уникальному ограничению (search_query_id, snapshot_date);