### PR TITLE
fix: Исправление e2e-trigger конфигурации

### DIFF
--- a/.github/workflows/e2e-trigger.yml
+++ b/.github/workflows/e2e-trigger.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref_name }}
 
       - name: Get short SHA
         id: vars


### PR DESCRIPTION
Исправил e2e-trigger конфигурацию, убрав использование github.ref_name во время checkout_code шага